### PR TITLE
DOC: Fix analysis part Python version

### DIFF
--- a/docs/szbd_study_analysis_pipeline_desc.md
+++ b/docs/szbd_study_analysis_pipeline_desc.md
@@ -158,8 +158,7 @@ Tools:
 
 ## Installation
 
-The pipeline was developed on an Ubuntu 22.04.3 LTS machine using Python
-3.8.17 (analysis) and Python 3.10.12 (data organization/standardization).
+The pipeline was developed on an Ubuntu 22.04.3 LTS machine using Python 3.10.
 
 Although not shown below, advanced users are encouraged to install the Python
 packages within a virtual environment. This minimizes the risk of


### PR DESCRIPTION
Fix analysis part Python version: it was believed that Python 3.8 had been used due to WMA, but it turned out that a successful Python 3.10 installation had been done for WMA.

Remove the patch versions to keep things as general as possible as both the data organization/standardization and analysis run on Python 3.10.