### PR TITLE
ENH: Add WMA documentation URL to pipeline description

### DIFF
--- a/docs/szbd_study_analysis_pipeline_desc.md
+++ b/docs/szbd_study_analysis_pipeline_desc.md
@@ -151,8 +151,8 @@ Tools:
   - Documentation: -
   - Code repository: https://github.com/pnlbwh/ukftractography
 - White Matter Analysis (WMA)
-  - Website: -
-  - Documentation: https://dmri.slicer.org/whitematteranalysis/
+  - Website: https://dmri.slicer.org/whitematteranalysis/
+  - Documentation: https://whitematteranalysis.readthedocs.io/en/latest/
   - Code repository: https://github.com/SlicerDMRI/whitematteranalysis
 - ORG Atlas
   - Website: -


### PR DESCRIPTION
Add WMA documentation URL to pipeline description, and set the GitHub pages deployment to the webiste field.