### PR TITLE
DOC: Render LaTeX math syntax

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,6 +28,7 @@ extensions = [
     "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "sphinx.ext.mathjax",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/users_guide.md
+++ b/docs/source/users_guide.md
@@ -11,7 +11,7 @@ The assumptions in this pipeline are as follows:
 - All participants are assumed to have AP/PA dMRI acquisitions.
 - All participants are assumed to have field map acquisitions.
 - All participants are assumed to have T1w acquisitions.
-- All participants are assumed to have $b = 3000$ s/mm^2 dMRI data.
+- All participants are assumed to have $$b = 3000$$ s/mm^2 dMRI data.
 - The data layout is kept consistent across runs: the only change may be in
   the participant identifier in the folders and filenames.
 - Generally, it is assumed that scripts are launched from a path where they


### PR DESCRIPTION
Render LaTeX math syntax: add the `mathjax` Sphinx extension.