### PR TITLE
ENH: Transition to newer `SCILPY`

### DIFF
--- a/docs/source/users_guide.md
+++ b/docs/source/users_guide.md
@@ -284,7 +284,7 @@ Versions used are:
 #### Versions
 
 Versions used are:
-- SCILPY (Scilus container): scilus 1.5.0
+- SCILPY (Scilus container): scilus 2.0.2
 - DWIConvert: (see SlicerDMRI version in [Analysis-versions](#analysis-versions))
 - SimpleITK: 2.2.1
 
@@ -473,7 +473,7 @@ tool.
        /mnt/data/study_name_bids_data/qsiprep/sub-001/dwi/sub-001_acq-dir99_space-T1w_desc-preproc_dwi.nii.gz \
        /mnt/data/study_name_bids_data/qsiprep/sub-001/dwi/sub-001_acq-dir99_space-T1w_desc-preproc_dwi.bval \
        /mnt/data/study_name_bids_data/qsiprep/sub-001/dwi/sub-001_acq-dir99_space-T1w_desc-preproc_dwi.bvec \
-       /mnt/data/containers/scilus/containers_scilus_1.5.0.sif
+       /mnt/data/containers/scilus/scilus-2.0.2.sif
    ```
 
    **Note:** When executing the above script the shell data concatenation step
@@ -634,39 +634,6 @@ parameters in the `ukf_compute_tractography.sh` script), and other parameters
 are kept to their default values. The proposed values were found to be
 appropriate for the data used during the development. Users are encouraged to
 adjust the parameter values if results are suboptimal after visual inspection.
-
-### Python packages
-
-Scilus 1.5.0 requires `NumPy < 1.25.0`: if `NumPy` is installed system-wide,
-and it is picked up when running `scilpy_prepare_shell_data.sh` (despite using
-the container), if `NumPy`'s version is `>= 1.25.0`, the following error will
-be raised:
-
-```
-Traceback (most recent call last):
-  File "/usr/local/bin/scil_extract_b0.py", line 33, in <module>
-    sys.exit(load_entry_point('scilpy', 'console_scripts', 'scil_extract_b0.py')())
-  File "/usr/local/bin/scil_extract_b0.py", line 25, in importlib_load_entry_point
-    return next(matches).load()
-  File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
-    module = import_module(match.group('module'))
-  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
-    return _bootstrap._gcd_import(name[level:], package, level)
-  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
-  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
-  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
-  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
-  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
-  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
-  File "/scilpy/scripts/scil_extract_b0.py", line 14, in <module>
-    from dipy.core.gradients import gradient_table
-  File "/usr/local/lib/python3.10/dist-packages/dipy/__init__.py", line 41, in <module>
-    from numpy.testing import Tester
-ImportError: cannot import name 'Tester' from 'numpy.testing' (/home/<username>/.local/lib/python3.10/site-packages/numpy/testing/__init__.py)
-```
-
-In order to solve this, `NumPy` needs to be downgraded, i.e.
-`pip install --upgrade numpy==1.24`.
 
 ## Citations
 

--- a/scripts/scilpy_prepare_shell_data.sh
+++ b/scripts/scilpy_prepare_shell_data.sh
@@ -86,7 +86,7 @@ function compose_filename_from_basename() {
 
 # Extract mean b0
 
-# https://scilpy.readthedocs.io/en/stable/scripts/scil_extract_b0.html
+# https://scilpy.readthedocs.io/en/stable/scripts/scil_dwi_extract_b0.html
 
 b0_thr=20
 
@@ -98,7 +98,7 @@ singularity exec \
   --bind ${work_dirname} \
   --workdir ${work_dirname} \
   ${scilus_singularity_fname} \
-  scil_extract_b0.py \
+  scil_dwi_extract_b0.py \
   ${in_nifti_fname} \
   ${in_bval_fname} \
   ${in_bvec_fname} \
@@ -135,7 +135,7 @@ echo ${out_b0_mean_4d_bvec_fname}
 
 # Extract b-value
 
-# https://scilpy.readthedocs.io/en/stable/scripts/scil_extract_dwi_shell.html
+# https://scilpy.readthedocs.io/en/stable/scripts/scil_dwi_extract_shell.html
 
 bval=3000
 bval_tol=100
@@ -152,7 +152,7 @@ singularity exec \
   --bind ${work_dirname} \
   --workdir ${work_dirname} \
   ${scilus_singularity_fname} \
-  scil_extract_dwi_shell.py \
+  scil_dwi_extract_shell.py \
   ${in_nifti_fname} \
   ${in_bval_fname} \
   ${in_bvec_fname} \
@@ -169,7 +169,7 @@ echo ${out_bval_shell_bvec_fname}
 
 # Concatenate mean b0 and b-value data
 
-# https://scilpy.readthedocs.io/en/stable/scripts/scil_concatenate_dwi.html
+# https://scilpy.readthedocs.io/en/stable/scripts/scil_dwi_concatenate.html
 
 b0_mean_bval_shell_label=${b0_mean_label}${dash}${bval_label}${bval}
 
@@ -183,7 +183,7 @@ singularity exec \
   --bind ${work_dirname} \
   --workdir ${work_dirname} \
   ${scilus_singularity_fname} \
-  scil_concatenate_dwi.py \
+  scil_dwi_concatenate.py.py \
   ${out_b0_mean_bval_shell_nifti_fname} \
   ${out_b0_mean_bval_shell_bval_fname} \
   ${out_b0_mean_bval_shell_bvec_fname} \


### PR DESCRIPTION
Transition to newer `SCILPY`: a reasonable amount of time has elapsed since the pipeline was first prepared, and similar to QSIPrep, newer versions of `SCILPY` have been released. Adopt the 2.0.2 of the `scilus` container.

Update the Python script names and documentation links in the `scilpy_prepare_shell_data.sh` script to the names used by the newer `SCILPY` version.

Remove the no longer relevant old `scilus` and `NumPy`-related Python package version issue note.

Make the container name consistent with the naming convention adopted across the repository.