### PR TITLE
DOC: Transition to newer `SimpleITK`

### DIFF
--- a/docs/source/users_guide.md
+++ b/docs/source/users_guide.md
@@ -286,7 +286,7 @@ Versions used are:
 Versions used are:
 - SCILPY (Scilus container): scilus 2.0.2
 - DWIConvert: (see SlicerDMRI version in [Analysis-versions](#analysis-versions))
-- SimpleITK: 2.2.1
+- SimpleITK: 2.4.1
 
 ### <a id="analysis-installation"></a>Analysis
 


### PR DESCRIPTION
Transition to newer `SimpleITK`: a reasonable amount of time has elapsed since the pipeline was first prepared, and newer versions of `SimpleITK` have been released. Adopt version 2.4.1.