### PR TITLE
DOC: Use the DWI-computed braimask for UKF tractography

### DIFF
--- a/docs/source/users_guide.md
+++ b/docs/source/users_guide.md
@@ -524,7 +524,7 @@ tool.
 
    ```bash
    $ sitk_convert_mask_nifti2nrrd.sh \
-       /mnt/data/study_name_bids_data/qsiprep/sub-001/anat/sub-001_acq-dir99_space-ACPC_desc-brain_mask.nii.gz \
+       /mnt/data/study_name_bids_data/qsiprep/sub-001/dwi/sub-001_acq-dir99_space-ACPC_desc-brain_mask.nii.gz \
        /mnt/data/study_name_bids_data/nifti2nrrd/sub-001_acq-dir99_space-ACPC_desc-brain_mask.nrrd
    ```
 


### PR DESCRIPTION
Use the DWI-computed brainmask for UKF tractography: the QSIPrep version used when the pipeline was initially developed (0.19.0) worked correctly employing the T1w-derived brainmask for UKF tractography, but in the version that is being used currently (1.0.0rc1) the size of that mask does not match the DWI data/is not aligned with the DWI data, and thus UKF provides unexpected results.

As mostly default flags have been used to preprocess the data, the DWI data are only aligned into ACPC, and not to the T1w data.